### PR TITLE
azure: create separate stacks by copying and modifying only local.name

### DIFF
--- a/azure/autosched.tf
+++ b/azure/autosched.tf
@@ -1,5 +1,5 @@
 resource "azurerm_automation_account" "glory_to_ukraine" {
-  name                = "glory-to-ukraine"
+  name                = local.name
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   sku_name            = "Basic"

--- a/azure/ssh.tf
+++ b/azure/ssh.tf
@@ -1,5 +1,5 @@
 locals {
-  ssh_key_path = pathexpand("~/.ssh/glory_to_ukraine_azure")
+  ssh_key_path = pathexpand("~/.ssh/${local.name}")
 }
 
 resource "tls_private_key" "ssh" {


### PR DESCRIPTION
Hi @Yorkerrr ,

This minor fix makes it easier to create a separate azure stack for new tool:

1. `cd ptn-huilo && cp -r azure azure-new`
2. edit locals in main.tf and change name to new project `name = "glory-to-ukraine"` 
3. `rm azure-new/script.sh`
4. create `azure-new/script.sh` with commands required to start new tool

New stacks will be created alongside deployed previously and will be easy to remove.

Please consider merging this minor fix to master.

Regards,
imagifault